### PR TITLE
feat: go to marked tracks and regions from normal mode

### DIFF
--- a/definitions/main.lua
+++ b/definitions/main.lua
@@ -120,5 +120,7 @@ return {
     ["yy"] = "CopyTrack",
     ["zz"] = "ScrollToSelectedTracks",
     ["|"] = "SplitItemsAtEditCursor",
+    ["'"] = "MarkedTracks",
+    ["~"] = "MarkedRegion",
   },
 }


### PR DESCRIPTION
I found it useful to be able to access track marks and selection marks from normal mode. Feel free to reject if it doesn't work for you, I merged it into my custom RK branch already :)