### PR TITLE
Defocus docked feedback window automatically

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,12 +1,2 @@
-# These are supported funding model platforms
-
-github: myrrc
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
+github: [myrrc]
 ko_fi: michaelmuszynski
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-otechie: # Replace with a single Otechie username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/workflows/wf.yml
+++ b/.github/workflows/wf.yml
@@ -15,8 +15,7 @@ jobs:
         run: cd tests; chmod +x prepare; ./prepare
       - run: |
           export DISPLAY=:99; sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-          cd tests; chmod +x copy-configs patch-settings test
+          cd tests; chmod +x copy-configs test
           ./copy-configs
-          ./patch-settings
           ./test
           exit $?

--- a/.github/workflows/wf.yml
+++ b/.github/workflows/wf.yml
@@ -14,6 +14,8 @@ jobs:
       - if: steps.cache.outputs.cache-hit != 'true'
         run: cd tests; chmod +x prepare; ./prepare
       - run: |
+          # We can run local tests with feedback window, but in CI something goes wrong
+          sed -i 's/show_feedback_window = true/show_feedback_window = false/g' ../internal/definitions/config.lua
           export DISPLAY=:99; sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
           cd tests; chmod +x copy-configs test
           ./copy-configs

--- a/.github/workflows/wf.yml
+++ b/.github/workflows/wf.yml
@@ -15,7 +15,7 @@ jobs:
         run: cd tests; chmod +x prepare; ./prepare
       - run: |
           # We can run local tests with feedback window, but in CI something goes wrong
-          sed -i 's/show_feedback_window = true/show_feedback_window = false/g' ../internal/definitions/config.lua
+          sed -i 's/show_feedback_window = true/show_feedback_window = false/g' internal/definitions/config.lua
           export DISPLAY=:99; sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
           cd tests; chmod +x copy-configs test
           ./copy-configs

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,9 +1,0 @@
-branches: master
-repositoryUrl: https://github.com/gwatcha/reaper-keys
-plugins:
-- "@semantic-release/commit-analyzer"
-- "@semantic-release/release-notes-generator"
-- - "@semantic-release/github"
-  - assets:
-    - dist/*
-- "@semantic-release/git"

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,0 @@
-lint:
-	luacheck internal/ --globals gfx reaper

--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ to [examples](#some-ideas-to-start-with).
 ## Installation
 
 - Add `https://raw.githubusercontent.com/gwatcha/reaper-keys/master/index.xml` to Reapack.
-- Optionally, install [SWS](https://sws-extension.org/) (by hand or from ReaTeam
-  Extensions). Although this extension _may_ work without SWS, the experience will be
-  worse.
+- Install [SWS](https://sws-extension.org/) by hand or from ReaTeam Extensions.
 
 ## Features
 ### Bind key sequences
@@ -152,16 +150,16 @@ For running tests locally you'd need some Linux distribution with X11 and `xdoto
 
 ```sh
 cd tests;
-chmod +x prepare copy-configs patch-settings test
+chmod +x prepare copy-configs test
 
 ./prepare # This will create a local Reaper installation
 ./copy-configs # This will make current instance of reaper-keys testable
-./patch-settings # Or change test to true in internal/definitions/config.lua
 ./test # This will run every test and compare with reference projects
 ```
 
 If you don't use X11 you can have a look at `.github/workflows/wf.yml` to see how x11 is
 emulated with Xvfb.
+Use `./test -s` to skip first invocation which bypasses "Still evaluating" window.
 
 ### Writing tests
 

--- a/Scripts/install-reaper-keys.lua
+++ b/Scripts/install-reaper-keys.lua
@@ -115,8 +115,7 @@ local keymap = io.open(keymap_path, "w")
 if not keymap then return reaper.MB("Failed to create " .. keymap_path, "Error", 0) end
 
 function KEY(mod_id, key_id, command_id, section_id)
-    return ("KEY %d %d %s %d\nKEY %d %d 101 102\n"):format(
-        mod_id, key_id, command_id, section_id, mod_id, key_id)
+    return ("KEY %d %d %s %d\n"):format(mod_id, key_id, command_id, section_id)
 end
 
 local parent_dir = debug.getinfo(1, "S").source:match "@?(.*)[\\/].*[\\/]"
@@ -124,7 +123,6 @@ local command_path = concat_path(parent_dir, "internal", "rk.lua")
 local sections = { midi = 32060, main = 0 }
 for section_name, section_id in pairs(sections) do
     local command_id = "_reaper_keys__" .. section_name
-    -- 260 focuses window on every key press so 516 is only option
     keymap:write(('SCR 516 %d %s "reaper-keys" "%s"\n'):format(section_id, command_id, command_path))
 
     for group_name, group in pairs(key_groups) do

--- a/Scripts/install-reaper-keys.lua
+++ b/Scripts/install-reaper-keys.lua
@@ -1,5 +1,5 @@
 -- @description reaper-keys: map keystroke combinations to actions like in vim
--- @version 2.0.0-a2
+-- @version 2.0.0-a3
 -- @author gwatcha
 -- @links
 --   GitHub repository https://github.com/gwatcha/reaper-keys
@@ -115,7 +115,8 @@ local keymap = io.open(keymap_path, "w")
 if not keymap then return reaper.MB("Failed to create " .. keymap_path, "Error", 0) end
 
 function KEY(mod_id, key_id, command_id, section_id)
-    return ("KEY %d %d %s %d\n"):format(mod_id, key_id, command_id, section_id)
+    return ("KEY %d %d %s %d\nKEY %d %d 101 102\n"):format(
+        mod_id, key_id, command_id, section_id, mod_id, key_id)
 end
 
 local parent_dir = debug.getinfo(1, "S").source:match "@?(.*)[\\/].*[\\/]"

--- a/internal/definitions/actions.lua
+++ b/internal/definitions/actions.lua
@@ -157,6 +157,8 @@ return {
     FitSelectedItemsByStretching = 41206,
     FitNotes = { 40754, midiCommand = true },
     FocusMain = "_S&M_WNMAIN",
+    FocusTracks = "_BR_FOCUS_TRACKS",
+    FocusMidiEditor = "_SN_FOCUS_MIDI_EDITOR",
     FolderChildren = { "SelectFolderChildren", "ScrollToSelectedTracks" },
     FolderParent = { "SelectFolderParent", "ScrollToSelectedTracks" },
     Folder = { "SelectFolder", "ScrollToSelectedTracks" },

--- a/internal/definitions/bindings.lua
+++ b/internal/definitions/bindings.lua
@@ -132,6 +132,7 @@ local global = { -- applies both to main and midi
             ["c"] = "CycleRippleEditMode",
             f = "SoloInFront",
             F = "ResetFeedbackWindow",
+            M = "ToggleMasterMonoStereo",
         } },
         ["i"] = { "+insert", {
             ["f"] = "InsertMediaFile",
@@ -357,13 +358,13 @@ local global = { -- applies both to main and midi
                 ["r"] = "ResetControlDevices",
                 [","] = "ShowPreferences", -- remove in 2.1
                 ["S"] = "UnsoloAllTracks",
-                ["s"] = { "+show/hide", {
+                ["s"] = { "+show/hide", { -- remove in 2.1
                     ["x"] = "ShowRoutingMatrix",       -- remove in 2.1
                     ["w"] = "ShowWiringDiagram",       -- remove in 2.1
                     ["t"] = "ShowTrackManager",        -- remove in 2.1
                     ["f"] = "ShowMonitoringFx",        -- remove in 2.1
                     ["m"] = "ToggleShowMasterTrack",   -- remove in 2.1
-                    ["M"] = "ToggleMasterMonoStereo",
+                    ["M"] = "ToggleMasterMonoStereo",  -- remove in 2.1
                     ["r"] = "ShowRegionMarkerManager", -- remove in 2.1
                 } },
                 ["f"] = { "+fx", {

--- a/internal/definitions/config.lua
+++ b/internal/definitions/config.lua
@@ -71,11 +71,10 @@ local gui = {
 
 local general = {
     show_start_up_message = true,
-    dock_feedback_window = false,
+    dock_feedback_window = true,
     show_feedback_window = true,
     search_for_custom_config = false,
     profile = false,
-    test = false,
     -- should operators in visual modes reset the selection or have it persist?
     persist_visual_timeline_selection = true,
     persist_visual_track_selection = false,

--- a/internal/gui/feedback/controller.lua
+++ b/internal/gui/feedback/controller.lua
@@ -56,7 +56,6 @@ local startup_msg =
     "- Press <CM-x> (Ctrl + Alt + x) to open up a keybinding menu.\n" ..
     "- Everything you need to configure reaper-keys is in REAPER/Scripts/reaper-keys/internal/definitions/\n" ..
     "- If you would like to hide this message, set the option in internal/definitions/config.lua\n" ..
-    "- If you set that option there will be no one to protect you from the focus stealing of the " ..
     "feedback window.\n" ..
     "\t Your mother loves you"
 local feedback_view = nil
@@ -66,7 +65,7 @@ function feedback.update()
     local just_opened = reaper_state.clearJustOpenedFlag()
 
     if feedback_view_open and not just_opened then
-        local update_number = model.getKey("update_number") or 0
+        local update_number = tonumber(model.getKey("update_number") or 0)
         if update_number > 20 then update_number = 0 end
         model.setKeys({ update_number = update_number + 1 })
         return
@@ -78,6 +77,10 @@ function feedback.update()
     if config.show_start_up_message and not config.test then
         reaper.ShowMessageBox(startup_msg, "Reaper Keys Open Message", 1)
     end
+
+    -- o or O on first track don't focus rename field
+    -- defocus window, otherwise, most commands won't work
+    -- reaper.Main_OnCommand(reaper.NamedCommandLookup("_BR_FOCUS_TRACKS"), 0)
 
     model.setKeys({ open = true })
 

--- a/internal/gui/feedback/controller.lua
+++ b/internal/gui/feedback/controller.lua
@@ -53,10 +53,10 @@ end
 local startup_msg =
     "Hello from inside Reaper Keys! I see the feedback window just opened... " ..
     "Here are some things I have been told to tell you:\n" ..
+    "- If the feedback window is focused and not docked, I can't hear keys being pressed, be sure to unfocus it.\n" ..
     "- Press <CM-x> (Ctrl + Alt + x) to open up a keybinding menu.\n" ..
     "- Everything you need to configure reaper-keys is in REAPER/Scripts/reaper-keys/internal/definitions/\n" ..
     "- If you would like to hide this message, set the option in internal/definitions/config.lua\n" ..
-    "feedback window.\n" ..
     "\t Your mother loves you"
 local feedback_view = nil
 

--- a/internal/gui/feedback/controller.lua
+++ b/internal/gui/feedback/controller.lua
@@ -53,7 +53,6 @@ end
 local startup_msg =
     "Hello from inside Reaper Keys! I see the feedback window just opened... " ..
     "Here are some things I have been told to tell you:\n" ..
-    "- If the feedback window is focused, I can't hear keys being pressed, be sure to unfocus it.\n" ..
     "- Press <CM-x> (Ctrl + Alt + x) to open up a keybinding menu.\n" ..
     "- Everything you need to configure reaper-keys is in REAPER/Scripts/reaper-keys/internal/definitions/\n" ..
     "- If you would like to hide this message, set the option in internal/definitions/config.lua\n" ..
@@ -66,36 +65,35 @@ function feedback.update()
     local feedback_view_open = model.getKey("open")
     local just_opened = reaper_state.clearJustOpenedFlag()
 
-    if not feedback_view_open or just_opened then
-        feedback_view = FeedbackView:new()
-        feedback_view:open()
-
-        if config.show_start_up_message and not config.test then
-            reaper.ShowMessageBox(startup_msg, "Reaper Keys Open Message", 1)
-        end
-
-        model.setKeys({ open = true })
-
-        if config.profile then
-            local path = '/Scripts/ReaTeam Scripts/Development/cfillion_Lua profiler.lua'
-            Profiler = dofile(reaper.GetResourcePath() .. path)
-            Profiler.attachToWorld()
-            Profiler.start()
-            Profiler.run()
-        end
-
-        reaper.atexit(function()
-            model.setKeys({ open = false })
-            local window_settings = feedback_view:getWindowSettings()
-            model.setKeys({ window_settings = window_settings })
-        end)
-    else
-        local update_number = model.getKey("update_number")
-        if not update_number or update_number > 20 then
-            update_number = 0
-        end
+    if feedback_view_open and not just_opened then
+        local update_number = model.getKey("update_number") or 0
+        if update_number > 20 then update_number = 0 end
         model.setKeys({ update_number = update_number + 1 })
+        return
     end
+
+    feedback_view = FeedbackView:new()
+    feedback_view:open()
+
+    if config.show_start_up_message and not config.test then
+        reaper.ShowMessageBox(startup_msg, "Reaper Keys Open Message", 1)
+    end
+
+    model.setKeys({ open = true })
+
+    if config.profile then
+        local path = '/Scripts/ReaTeam Scripts/Development/cfillion_Lua profiler.lua'
+        Profiler = dofile(reaper.GetResourcePath() .. path)
+        Profiler.attachToWorld()
+        Profiler.start()
+        Profiler.run()
+    end
+
+    reaper.atexit(function()
+        model.setKeys({ open = false })
+        local window_settings = feedback_view:getWindowSettings()
+        model.setKeys({ window_settings = window_settings })
+    end)
 end
 
 function feedback.displayMessage(message)

--- a/internal/gui/feedback/controller.lua
+++ b/internal/gui/feedback/controller.lua
@@ -78,10 +78,6 @@ function feedback.update()
         reaper.ShowMessageBox(startup_msg, "Reaper Keys Open Message", 1)
     end
 
-    -- o or O on first track don't focus rename field
-    -- defocus window, otherwise, most commands won't work
-    -- reaper.Main_OnCommand(reaper.NamedCommandLookup("_BR_FOCUS_TRACKS"), 0)
-
     model.setKeys({ open = true })
 
     if config.profile then

--- a/internal/gui/feedback/controller.lua
+++ b/internal/gui/feedback/controller.lua
@@ -74,7 +74,7 @@ function feedback.update()
     feedback_view = FeedbackView:new()
     feedback_view:open()
 
-    if config.show_start_up_message and not config.test then
+    if config.show_start_up_message then
         reaper.ShowMessageBox(startup_msg, "Reaper Keys Open Message", 1)
     end
 

--- a/internal/state_machine/state_machine.lua
+++ b/internal/state_machine/state_machine.lua
@@ -139,6 +139,10 @@ local function input()
 
     feedback.displayState(new_state)
     feedback.update()
+
+    -- This works only when window is docked, nothing we can do otherwise
+    local defocus_window = section_id == 0 and "_BR_FOCUS_TRACKS" or "_SN_FOCUS_MIDI_EDITOR"
+    reaper.Main_OnCommand(reaper.NamedCommandLookup(defocus_window), 0)
 end
 
 return input

--- a/internal/state_machine/state_machine.lua
+++ b/internal/state_machine/state_machine.lua
@@ -3,6 +3,7 @@ local buildCommand = require('command.builder')
 local handleCommand = require('command.handler')
 local getPossibleFutureEntries = require('command.completer')
 local config = require 'definitions.config'.general
+local actions = require 'definitions.actions'
 local log = require('utils.log')
 local format = require('utils.format')
 local feedback = require('gui.feedback.controller')
@@ -141,8 +142,12 @@ local function input()
     feedback.update()
 
     -- This works only when window is docked, nothing we can do otherwise
-    local defocus_window = section_id == 0 and "_BR_FOCUS_TRACKS" or "_SN_FOCUS_MIDI_EDITOR"
+    local defocus_window = section_id == 0
+        and actions.FocusTracks or actions.FocusMidiEditor
     reaper.Main_OnCommand(reaper.NamedCommandLookup(defocus_window), 0)
+
+    -- When we insert track with feedback window closed, it steals focus and track is not renamed
+    if hotkey.key:lower() == "o" then reaper.Main_OnCommand(actions.RenameTrack, 0) end
 end
 
 return input

--- a/internal/state_machine/state_machine.lua
+++ b/internal/state_machine/state_machine.lua
@@ -122,6 +122,7 @@ end
 
 local function input()
     local _, _, section_id, _, _, _, _, ctx = reaper.get_action_context()
+    log.trace(reaper.get_action_context())
     if ctx == "" then return end
     ---@type KeyPress
     local hotkey = { context = section_id == 0 and "main" or "midi", key = ctxToState(ctx) }

--- a/internal/state_machine/state_machine.lua
+++ b/internal/state_machine/state_machine.lua
@@ -123,7 +123,6 @@ end
 
 local function input()
     local _, _, section_id, _, _, _, _, ctx = reaper.get_action_context()
-    log.trace(reaper.get_action_context())
     if ctx == "" then return end
     ---@type KeyPress
     local hotkey = { context = section_id == 0 and "main" or "midi", key = ctxToState(ctx) }

--- a/internal/state_machine/state_machine.lua
+++ b/internal/state_machine/state_machine.lua
@@ -129,14 +129,14 @@ local function input()
     local hotkey = { context = section_id == 0 and "main" or "midi", key = ctxToState(ctx) }
 
     log.info("Input: " .. format.line(hotkey))
-    if config.show_feedback_window and not config.test then feedback.clear() end
+    if config.show_feedback_window then feedback.clear() end
 
     local state = state_interface.get()
     local new_state = step(state, hotkey)
     state_interface.set(new_state)
 
     log.info("New state: " .. format.block(new_state))
-    if config.test or not config.show_feedback_window then return end
+    if not config.show_feedback_window then return end
 
     feedback.displayState(new_state)
     feedback.update()

--- a/tests/compare
+++ b/tests/compare
@@ -3,11 +3,7 @@ from pathlib import Path
 from sys import argv
 left_file, right_file = Path(argv[1]).read_text(), Path(argv[2]).read_text()
 out = 0
-ignored_keys = ["<TRACK", "TRACKID", "EGUID"]
-
-if len(left_file) != len(right_file):
-    print("Different sizes")
-    out = 1
+ignored_keys = ["<TRACK", "TRACKID", "EGUID", "FIXEDLANES"]
 
 # skip project declaration
 for left, right in zip(left_file.split("\n")[1:], right_file.split("\n")[1:]):

--- a/tests/patch-settings
+++ b/tests/patch-settings
@@ -1,2 +1,0 @@
-#!/bin/sh
-sed -i 's/test = false/test = true/g' ../internal/definitions/config.lua

--- a/tests/prepare
+++ b/tests/prepare
@@ -1,5 +1,5 @@
 #!/bin/bash
-wget -qO- http://reaper.fm/files/7.x/reaper715_linux_x86_64.tar.xz | tar xfJ -
+wget -qO- http://reaper.fm/files/7.x/reaper718_linux_x86_64.tar.xz | tar xfJ -
 mv reaper_linux_x86_64/REAPER reaper
 wget -q https://github.com/reaper-oss/sws/releases/download/v2.14.0.1/reaper_sws-x86_64.so -P reaper/UserPlugins
 rm -fr reaper_linux_x86_64 \

--- a/tests/test
+++ b/tests/test
@@ -1,6 +1,6 @@
 #!/bin/bash
 ret=0
-timeout 5 ./reaper/reaper -new -nosplash &>/dev/null # still evaluating
+[ $# -eq 0 ] && timeout 6 ./reaper/reaper -new -nosplash &>/dev/null # still evaluating
 
 for test in *.rks; do
     echo "Running $test"


### PR DESCRIPTION
- Fix o and O when feedback window is closed
- add qM - toggle master mono/stereo
- Defocus config window when opened in docked mode
- Remove `configs.test` option and `copy-configs` test script
- Fix README -- SWS is mandatory to install
- Raise Reaper version in CI to 7.18
